### PR TITLE
Various changes to logging, command execution and stuff

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,10 @@ gem 'sinatra'
 gem 'sinatra-contrib'
 
 group :development, :test do
-  gem 'pry'
-  gem 'pry-byebug'
+  group :pry do
+    gem 'pry'
+    gem 'pry-byebug'
+  end
 end
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ A basic `systemd` unit file can be found [here](support/power-server.service). T
 The `puma` server daemon can be started manually with:
 
 ```
-bin/puma -p <port> -e production -d
+bin/puma -p <port> -e production -d \
+         --redirect-stdout <stdout-log-file-path> \
+         --redirect-stderr <stderr-log-file-path>
 ```
 
 ## Stopping the Server

--- a/README.md
+++ b/README.md
@@ -151,17 +151,20 @@ kill -s SIGINT <puma-pid>
 The API requires all requests to carry with a [jwt](https://jwt.io). Within the token either `user: true` or `admin: true` needs to be set.
 
 The following `rake` tasks are used to generate tokens with 30 days expiry. Tokens from other sources will be accepted as long as they:
-1. Where signed with the same shared secret, and
-2. An [expiry claim](https://tools.ietf.org/html/rfc7519#section-4.1.4) has been made.
+1. Where signed with the same `jwt_shared_secret`, and
+2. Make an [expiry claim](https://tools.ietf.org/html/rfc7519#section-4.1.4).
 
-As the shared secret is environment dependant, the `RACK_ENV` must be set within your environment.
+As this command is dependant on the `jwt_shared_secret`, the `RACK_ENV` must be set within your environment. By default the tokens will expire in 30 days. This can be optionally changed by specifying how long the token should be valid for in days.
 
 ```
 # Set the rack environment
 export RACK_ENV=production
 
-# Generate a user token
+# Generate a user token (Expires in 30 days)
 rake token:user
+
+# Generate a token that expires in 365 days
+rake token:user[365]
 ```
 
 # Contributing

--- a/Rakefile
+++ b/Rakefile
@@ -61,6 +61,7 @@ task require: :require_bundler do
 end
 
 task console: :require do
+  Bundler.require(:pry)
   binding.pry
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -65,12 +65,10 @@ task console: :require do
   binding.pry
 end
 
-# task 'token:admin' => :require do
-#   # puts User.new(admin: true).generate_jwt
-#   raise NotImplementedError
-# end
+task('token:admin') { raise NotImplementedError }
 
-task 'token:user' => :require do
-  puts Token.new.generate_jwt
+task 'token:user', [:days] => :require do |task, args|
+  token = Token.new.tap { |t| t.exp_days = args[:days].to_i if args[:days] }
+  puts token.generate_jwt
 end
 

--- a/app.rb
+++ b/app.rb
@@ -37,6 +37,8 @@ NODE_REGEX = /[[:alnum:]]+(\[\d+(-\d+)\])?/
 
 configure do
   set :show_exceptions, :after_handler
+  set :logger, Logger.new($stderr)
+  enable :logging
 end
 
 helpers do
@@ -87,7 +89,7 @@ helpers do
   end
 
   def commands(action)
-    Commands.new(action, nodes).tap(&:run_in_parallel).commands
+    Commands.new(action, nodes).tap { |c| c.run_in_parallel(logger) }.commands
   end
 end
 

--- a/app/command.rb
+++ b/app/command.rb
@@ -50,6 +50,10 @@ end
 Command = Struct.new(:action, :node) do
   extend Memoist
 
+  def self.working_dir
+    Figaro.env.scripts_dir
+  end
+
   def jsonapi_serializer_class_name
     if action == :status
       StatusCommandSerializer
@@ -67,10 +71,13 @@ Command = Struct.new(:action, :node) do
                    .map { |v| "#{v}=\"#{node.attributes[v]}\"" }
                    .join("\n")
     <<~CMD
-      # Configuration Parameters For: #{node.name}
+      # Working Directory:
+      cd #{self.class.working_dir}
+
+      # Configuration Parameters: #{node.name}
       #{args}
 
-      # Command For: #{node.platform}##{action}
+      # Run: #{node.platform}:#{action}
       #{platform[action]}
     CMD
   end

--- a/app/models.rb
+++ b/app/models.rb
@@ -71,7 +71,7 @@ class Nodes < Hashie::Mash
   end
 
   def [](key)
-    super(key) || Node.new(name: key, attributes: { name: key })
+    super(key) || Node.new(name: key, attributes: { name: key }, missing: true)
   end
 end
 
@@ -79,8 +79,13 @@ class Node < Hashie::Dash
   include Hashie::Extensions::Dash::Coercion
 
   property :name,       required: true
+  property :missing,    default: false
   property :platform,   default: :missing
   property :attributes, required: true, coerce: Hashie::Mash
+
+  def missing?
+    missing
+  end
 end
 
 class Platforms < Hashie::Mash

--- a/app/serializers.rb
+++ b/app/serializers.rb
@@ -33,6 +33,8 @@ class BaseCommandSerializer
   attributes :action
   attribute(:node_name) { object.id }
   attribute(:platform) { object.platform.name }
+
+  attribute(:missing) { object.node.missing }
 end
 
 class CommandSerializer < BaseCommandSerializer

--- a/app/token.rb
+++ b/app/token.rb
@@ -76,6 +76,14 @@ class Token < Hashie::Trash
     end
   end
 
+  def exp_days=(days)
+    self.exp = days.days.from_now.to_i
+  end
+
+  def exp_days
+    (self.exp - Time.now.to_i)/(24*60*60)
+  end
+
   def token_attributes
     { admin: admin, exp: exp }
   end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -25,6 +25,3 @@ topology_config:  config/topology.yaml
 # STATIC DEFAULTS:
 num_worker_commands: '50'
 
-development:
-  topology_config: config/topology.example.yaml
-

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -21,6 +21,7 @@
 # The following may use relative paths from the install directory
 # or hard coded to be an absolute path
 topology_config:  config/topology.yaml
+scripts_dir:      var/libexec
 
 # STATIC DEFAULTS:
 num_worker_commands: '50'

--- a/config/application.yaml.reference
+++ b/config/application.yaml.reference
@@ -32,6 +32,13 @@ jwt_shared_secret:
 topology_config:
 
 # =============================================================================
+# Scripts Directory
+# Specify the working directory for the commands. This is to allow the commands
+# to call other scripts easily
+# =============================================================================
+scripts_dir:
+
+# =============================================================================
 # Number of Worker Commands
 # Specify the number of commands that will be ran in parallel. This is to
 # prevent network timeouts due to a large number of requests being made

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -42,7 +42,7 @@ Figaro.load
 ENV['app_root_dir'] = File.expand_path('../..', __dir__)
 root_dir = ENV['app_root_dir']
 
-relative_keys = ['topology_config']
+relative_keys = ['topology_config', 'scripts_dir']
 Figaro.require_keys('jwt_shared_secret', 'num_worker_commands', *relative_keys)
 
 # Sets relative keys from the install directory

--- a/support/power-server.service
+++ b/support/power-server.service
@@ -11,7 +11,7 @@ WorkingDirectory=/opt/flight/opt/power-server
 
 # The application must be fully configured within the user's environment OR
 # within 'config/application.yaml'
-ExecStart=bin/puma -p 8080 -e production -d \
+ExecStart=bin/puma -p 6302 -e production -d \
                     --redirect-stdout /opt/flight/log/power-server.log \
                     --redirect-stderr /opt/flight/log/power-server.log
 

--- a/support/power-server.service
+++ b/support/power-server.service
@@ -11,7 +11,9 @@ WorkingDirectory=/opt/flight/opt/power-server
 
 # The application must be fully configured within the user's environment OR
 # within 'config/application.yaml'
-ExecStart=bin/puma -p 8080 -e production -d
+ExecStart=bin/puma -p 8080 -e production -d \
+                    --redirect-stdout /opt/flight/log/power-server.log \
+                    --redirect-stderr /opt/flight/log/power-server.log
 
 Restart=always
 

--- a/support/power-server.service
+++ b/support/power-server.service
@@ -11,7 +11,7 @@ WorkingDirectory=/opt/flight/opt/power-server
 
 # The application must be fully configured within the user's environment OR
 # within 'config/application.yaml'
-ExecStart=bin/puma -p 6302 -e production -d \
+ExecStart=bin/puma -p 6302 -e production \
                     --redirect-stdout /opt/flight/log/power-server.log \
                     --redirect-stderr /opt/flight/log/power-server.log
 


### PR DESCRIPTION
The following has now been implemented:
1. The commands are now logged to `stderr`. This can be combined with `puma` logging. Fixes #1 
2. The tokens can now have configurable expiry dates. Fixes #2 
3. The working directory for the commands is now within a script directory. Fixes #3
4. The `console` can now be opened in `production`.
5. The command response now flag if the `node` is missing as opposed to a command error