### PR TITLE
Integrate with `NodeattrServer` to provide group support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 gem 'activesupport'
 gem 'figaro'
 gem 'hashie'
+gem 'json_api_client'
 gem 'jsonapi-serializers'
 gem 'jwt'
 gem 'memoist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,37 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (6.0.1)
+      activesupport (= 6.0.1)
     activesupport (6.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     backports (3.15.0)
     byebug (11.0.1)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     diff-lcs (1.3)
+    faraday (0.17.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
     figaro (1.1.1)
       thor (~> 0.14)
     hashie (4.0.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
+    json_api_client (1.16.1)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      addressable (~> 2.2)
+      faraday (~> 0.15, >= 0.15.2)
+      faraday_middleware (~> 0.9)
+      rack (>= 0.2)
     jsonapi-serializers (1.0.1)
       activesupport
     jwt (2.2.1)
@@ -24,6 +39,7 @@ GEM
     method_source (0.9.2)
     minitest (5.13.0)
     multi_json (1.14.1)
+    multipart-post (2.1.1)
     mustermann (1.0.3)
     nio4r (2.5.2)
     parallel (1.19.0)
@@ -33,6 +49,7 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
+    public_suffix (4.0.1)
     puma (4.3.1)
       nio4r (~> 2.0)
     pundit (2.1.0)
@@ -84,6 +101,7 @@ DEPENDENCIES
   activesupport
   figaro
   hashie
+  json_api_client
   jsonapi-serializers
   jwt
   memoist

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The node `name` is implicitly set so it can be used as a variable and can not be
 Alternatively a previously configured cluster can be used by specifying the `remote` key in the config. This must not be used with the `static_nodes` to prevent conflicts. This will proxy all the requests `node` parameters to the `nodeattr-server`. If running `nodeattr-server` on localhost with default port configuration:
 
 ```
-remote: https://localhost:6301
+remote: http://localhost:6301
 ```
 
 A typical response from the `nodeattr-server` would be:

--- a/README.md
+++ b/README.md
@@ -130,11 +130,7 @@ The node `name` is implicitly set so it can be used as a variable and can not be
 
 #### Integrate with OpenFlightHPC:NodeattrServer
 
-Alternatively a previously configured cluster can be used by specifying the `remote` key in the config. This must not be used with the `static_nodes` to prevent conflicts. This will proxy all the requests `node` parameters to the `nodeattr-server`. If running `nodeattr-server` on localhost with default port configuration:
-
-```
-remote: http://localhost:6301
-```
+Alternatively a previously configured cluster can be used by specifying the `remote_url` key in the [core config](config/application/yaml). This must not be used with the `static_nodes` within the `topology`. The `remote_jwt` and `remote_cluster` keys must also be set as as these will be used to proxy `node`/`group` requests to the `nodeattr-server`.
 
 A typical response from the `nodeattr-server` would be:
 
@@ -159,7 +155,7 @@ HTTP/1.1 200 OK
 }
 ```
 
-The `platform` is extracted from the `params` hash and therefore may not be set. In this case a dummy "missing" platform is used which causes all the system commands to fail. All the other `params` are made available as replacements to the bash commands.
+The `platform` is extracted from the `params` hash and therefore may not be set. In this case a dummy "missing" platform is used which causes all the system commands to fail. All the other `params` are made available as replacements to the platform scripts.
 
 ### Setting Up Systemd
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ export jwt_shared_secret=<keep-this-secret-safe>
 vim config/application.yaml
 ```
 
-### Adding Nodes And Platforms
+### Configuring the Platform
 
-The layout of the cluster is specified in the topology config file which is stored as `config/topology.yaml` by default. It must specify the `nodes` and `platforms` key.
+The layout of the cluster is specified in the topology config file which is stored as `config/topology.yaml` by default.
 
 #### Getting Started
 
@@ -64,7 +64,7 @@ needs to be copied into place:
 cp config/topology.example.yaml config/topology.yaml
 ```
 
-All further actions will be preformed on `config/topology.yaml`. A basic list of `nodes` has been provided with this config. It is now safe to remove them.
+All further actions will be preformed on `config/topology.yaml`. A basic list of `static_nodes` have been provided with this config. It is now safe to remove them.
 
 #### Adding a Platform
 
@@ -95,9 +95,13 @@ NOTE: `Starting` and `Stopping` States
 
 The API only supports nodes in `on` or `off` power states. Transitionary states (such as `starting`/`stopping`) are not supported and can not be communicated through the API. In these cases, the `status` script should return a failure exit code but may return either 0 or `status_off_exit_code`. There is no preference for the last known state versus the likely future state.
 
-#### Adding the Nodes
+### Configuring the Nodes
 
-The `nodes` are also set within the `topology` config and are used to customise the bash commands. The generic layouts is:
+There are two ways the nodes can be specified within the `topology`, as a static list or dynamically by integrating with [nodeattr-server](https://github.com/openflighthpc/nodeattr-server).
+
+#### Static Nodes
+
+To statically define the nodes, the `static_nodes` key must be set within the topography config. To prevent conflicts with an upstream server, the `remote` key must not be set. Each node's parameters are used to customise the bash commands. The generic layout is:
 
 ```
 nodes:
@@ -123,6 +127,39 @@ nodes:
 The variables specified on the platform will preform a lookup against the nodes. This is primarily used to set some form of node identifier bash variable (e.g. `$ec2_id`) in the script. The exact keys depends on the `platform` configuration.
 
 The node `name` is implicitly set so it can be used as a variable and can not be overridden.
+
+#### Integrate with OpenFlightHPC:NodeattrServer
+
+Alternatively a previously configured cluster can be used by specifying the `remote` key in the config. This must not be used with the `static_nodes` to prevent conflicts. This will proxy all the requests `node` parameters to the `nodeattr-server`. If running `nodeattr-server` on localhost with default port configuration:
+
+```
+remote: https://localhost:6301
+```
+
+A typical response from the `nodeattr-server` would be:
+
+```
+GET /nodes/foo-cluster.bar
+
+HTTP/1.1 200 OK
+{
+  "data": {
+    "type": "nodes",
+    "id": "<id>",
+    "attributes": {
+      "name": "bar",
+      "params": {
+        "platform": "<platfrom>",
+        ... other parameters ...
+      }
+    },
+    ...
+  },
+  ...
+}
+```
+
+The `platform` is extracted from the `params` hash and therefore may not be set. In this case a dummy "missing" platform is used which causes all the system commands to fail. All the other `params` are made available as replacements to the bash commands.
 
 ### Setting Up Systemd
 

--- a/Rakefile
+++ b/Rakefile
@@ -43,14 +43,12 @@ task :require_bundler do
   ERROR
 
   Bundler.require(:default, ENV['RACK_ENV'].to_sym)
-
-  # Turns FakeFS off if running in test mode. The gem isn't installed in production
-  FakeFS.deactivate! if ENV['RACK_ENV'] == 'test'
 end
 
 task require: :require_bundler do
   require 'config/initializers/active_support'
   require 'config/initializers/figaro'
+  require 'config/initializers/logger'
   require 'app/nodeattr'
   require 'app/token'
   require 'app/command'

--- a/Rakefile
+++ b/Rakefile
@@ -55,6 +55,7 @@ task require: :require_bundler do
   require 'app/token'
   require 'app/command'
   require 'app/policies'
+  require 'app/records'
   require 'app/models'
   require 'app/serializers'
   require 'app'

--- a/app.rb
+++ b/app.rb
@@ -102,6 +102,16 @@ error Pundit::NotAuthorizedError do
   body "Forbidden"
 end
 
+error JsonApiClient::Errors::AccessDenied do
+  status 502
+  body 'Invalid upstream server configuration'
+end
+
+error JsonApiClient::Errors::ConnectionError do
+  status 504
+  body 'Failed to contact the upstream server'
+end
+
 get('/')    { json serialize_models(commands(:status)) }
 patch('/')  { json serialize_models(commands(:power_on)) }
 put('/')    { json serialize_models(commands(:restart)) }

--- a/app.rb
+++ b/app.rb
@@ -85,8 +85,25 @@ helpers do
                .uniq
   end
 
+  def groups_param
+    if match = NODEATTR_REGEX.match(params[:groups] || '')
+      match.to_s
+    else
+      halt 400, serialize_errors([{ groups: 'Unrecognised groups syntax' }]).to_json
+    end
+  end
+
+  def names_from_groups_param
+    groups_param.split(',')
+                .map { |n| Nodeattr.explode(n) }
+                .flatten
+                .uniq
+  end
+
   def nodes
-    names_from_nodes_param.map { |n| Topology::Cache.nodes[n] }
+    single_nodes = names_from_nodes_param.map { |n| Topology::Cache.nodes[n] }
+    group_nodes = names_from_groups_param.map { |g| Topology::Cache.nodes.where_group(g) }
+    [single_nodes, group_nodes].flatten.uniq
   end
 
   def commands(action)

--- a/app.rb
+++ b/app.rb
@@ -77,11 +77,15 @@ helpers do
     end
   end
 
-  def node_names
+  def names_from_nodes_param
     nodes_param.split(',')
                .map { |n| Nodeattr.explode_nodes(n) }
                .flatten
                .uniq
+  end
+
+  def node_names
+    names_from_nodes_param
   end
 
   def nodes

--- a/app.rb
+++ b/app.rb
@@ -38,7 +38,7 @@ NODEATTR_REGEX  = /\A(#{SINGLE_REGEX}(,#{SINGLE_REGEX})*)?\Z/
 
 configure do
   set :show_exceptions, :after_handler
-  set :logger, Logger.new($stderr)
+  set :logger, DEFAULT_LOGGER
   enable :logging
 end
 

--- a/app/nodeattr.rb
+++ b/app/nodeattr.rb
@@ -27,9 +27,9 @@
 # https://raw.githubusercontent.com/DougEverly/nodeattr/34f55c95a875ee478c24359b090b37ffdb8d4214/lib/nodeattr.rb
 
 module Nodeattr
-  def self.explode_nodes(nodes)
+  def self.explode(names)
     h = Array.new
-    m = nodes.match(/^(.*)\[(.*)\]$/)
+    m = names.match(/^(.*)\[(.*)\]$/)
     if m
       base = m[1]
       instances = m[2].split(',')
@@ -46,7 +46,7 @@ module Nodeattr
         end
       end
     else
-      h << nodes
+      h << names
     end
     h
   end

--- a/app/records.rb
+++ b/app/records.rb
@@ -32,6 +32,9 @@ require 'json_api_client'
 class Record < JsonApiClient::Resource
   self.site = Figaro.env.remote_url
   self.connection.faraday.authorization :Bearer, Figaro.env.remote_jwt
+  connection.use Faraday::Response::Logger do |logger|
+    logger.filter(/(Authorization: "Bearer )(.*)"/, '\1[REDACTED]"')
+  end
 end
 
 class NodeRecord < Record

--- a/app/records.rb
+++ b/app/records.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Power Server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Power Server is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Cloud. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Power Server, please visit:
+# https://github.com/openflighthpc/power-server
+#===============================================================================
+
+require 'json_api_client'
+
+class Record < JsonApiClient::Resource
+  self.site = Figaro.env.remote_url
+  self.connection.faraday.authorization :Bearer, Figaro.env.remote_jwt
+end
+
+class NodeRecord < Record
+  def self.resource_name
+    'nodes'
+  end
+
+  belongs_to :group, class_name: 'GroupRecord', shallow_path: true
+
+  property :name, type: :string
+  property :params, type: :hash
+end
+
+class GroupRecord < Record
+  def self.resource_name
+    'groups'
+  end
+end
+

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -34,4 +34,5 @@ num_worker_commands: '50'
 
 development:
   remote_url:       http://localhost:6301
+  remote_cluster:   default
   topology_config:  config/topology.example.yaml

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -15,7 +15,13 @@
 # export ... All the other REQUIRED configs ...
 
 # REQUIRED:
-# jwt_shared_secret:  # [REQUIRED]
+# jwt_shared_secret:  # [REQUIRED - Export for enhanced security]
+
+# ENABLE UPSTREAM MODE:
+# Uncomment the remote_url to put the server into upstream mode. This must not
+# be used with static_nodes.
+# remote_url: http://localhost:6301
+# remote_jwt: # [REQUIRED WHEN USING remote_url - Export for enhanced security]
 
 # DYNAMIC DEFAULTS:
 # The following may use relative paths from the install directory
@@ -26,3 +32,6 @@ scripts_dir:      var/libexec
 # STATIC DEFAULTS:
 num_worker_commands: '50'
 
+development:
+  remote_url:       http://localhost:6301
+  topology_config:  config/topology.example.yaml

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -18,10 +18,12 @@
 # jwt_shared_secret:  # [REQUIRED - Export for enhanced security]
 
 # ENABLE UPSTREAM MODE:
-# Uncomment the remote_url to put the server into upstream mode. This must not
-# be used with static_nodes.
+# Export the following configs to put the server into upstream mode.
+# Particular care should be taken not to hard set the `remote_jwt` in this
+# config for security reasons.
+remote_cluster: default
+# remote_jwt:
 # remote_url: http://localhost:6301
-# remote_jwt: # [REQUIRED WHEN USING remote_url - Export for enhanced security]
 
 # DYNAMIC DEFAULTS:
 # The following may use relative paths from the install directory
@@ -34,5 +36,4 @@ num_worker_commands: '50'
 
 development:
   remote_url:       http://localhost:6301
-  remote_cluster:   default
   topology_config:  config/topology.example.yaml

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -33,7 +33,12 @@ scripts_dir:      var/libexec
 
 # STATIC DEFAULTS:
 num_worker_commands: '50'
+log_level: info
 
 development:
   remote_url:       http://localhost:6301
   topology_config:  config/topology.example.yaml
+  log_level: debug
+
+test:
+  log_level: error

--- a/config/application.yaml.reference
+++ b/config/application.yaml.reference
@@ -41,9 +41,12 @@ topology_config:
 # signed by a different shared secret to this application. For security reasons
 # consider exporting the `remote_jwt` into the environment instead of hard
 # coding it.
+#
+# The remote_cluster must specify the default cluster the nodes belong to
 # =============================================================================
 remote_url:
 remote_jwt:
+remote_cluster:
 
 # =============================================================================
 # Scripts Directory

--- a/config/application.yaml.reference
+++ b/config/application.yaml.reference
@@ -32,6 +32,20 @@ jwt_shared_secret:
 topology_config:
 
 # =============================================================================
+# Remote NodeattrServer [OPTIONAL]
+# Configure the server with an upstream OpenFlightHPC/NodeattrServer. The
+# upstream URL is given by `remote_url`. To prevent conflicts with the
+# topology, this option can not be used with `static_nodes`.
+#
+# The JWT access token should be given as `remote_jwt`. This token may be
+# signed by a different shared secret to this application. For security reasons
+# consider exporting the `remote_jwt` into the environment instead of hard
+# coding it.
+# =============================================================================
+remote_url:
+remote_jwt:
+
+# =============================================================================
 # Scripts Directory
 # Specify the working directory for the commands. This is to allow the commands
 # to call other scripts easily

--- a/config/application.yaml.reference
+++ b/config/application.yaml.reference
@@ -63,3 +63,9 @@ scripts_dir:
 # =============================================================================
 num_worker_commands:
 
+# =============================================================================
+# Log Level
+# Specify which level of logging should be used. The supported values are:
+# fatal, error, warn, info, or debug
+# =============================================================================
+log_level:

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -43,7 +43,11 @@ ENV['app_root_dir'] = File.expand_path('../..', __dir__)
 root_dir = ENV['app_root_dir']
 
 relative_keys = ['topology_config', 'scripts_dir']
-Figaro.require_keys('jwt_shared_secret', 'num_worker_commands', *relative_keys)
+Figaro.require_keys(*['jwt_shared_secret',
+                      'num_worker_commands',
+                      *relative_keys].tap do |keys|
+                        keys << 'remote_jwt' if ENV['remote_url']
+                      end)
 
 # Sets relative keys from the install directory
 # NOTE: Does not affect the path if it is already absolute

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -46,7 +46,9 @@ relative_keys = ['topology_config', 'scripts_dir']
 Figaro.require_keys(*['jwt_shared_secret',
                       'num_worker_commands',
                       *relative_keys].tap do |keys|
-                        keys << 'remote_jwt' if ENV['remote_url']
+                        if ENV['remote_url']
+                          keys << 'remote_jwt' << 'remote_cluster'
+                        end
                       end)
 
 # Sets relative keys from the install directory

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -45,6 +45,7 @@ root_dir = ENV['app_root_dir']
 relative_keys = ['topology_config', 'scripts_dir']
 Figaro.require_keys(*['jwt_shared_secret',
                       'num_worker_commands',
+                      'log_level',
                       *relative_keys].tap do |keys|
                         if ENV['remote_url']
                           keys << 'remote_jwt' << 'remote_cluster'

--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -28,13 +28,19 @@
 #===============================================================================
 
 DEFAULT_LOGGER = Logger.new($stdout).tap do |logger|
-  case Sinatra::Application.environment
-  when :production
-    logger.level = Logger::INFO
-  when :test
-    logger.level = Logger::ERROR
+  logger.level = case Figaro.env.log_level.to_s
+  when 'fatal'
+    Logger::FATAL
+  when 'error'
+    Logger::ERROR
+  when 'warn'
+    Logger::WARN
+  when 'info'
+    Logger::INFO
+  when 'debug'
+    Logger::DEBUG
   else
-    logger.level = Logger::DEBUG
+    raise 'Unrecognised log level'
   end
 end
 

--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -27,30 +27,14 @@
 # https://github.com/openflighthpc/power-server
 #===============================================================================
 
-require 'json_api_client'
-
-class Record < JsonApiClient::Resource
-  self.site = Figaro.env.remote_url
-  self.connection.faraday.authorization :Bearer, Figaro.env.remote_jwt
-  connection.use Faraday::Response::Logger, DEFAULT_LOGGER do |logger|
-    logger.filter(/(Authorization: "Bearer )(.*)"/, '\1[REDACTED]"')
-  end
-end
-
-class NodeRecord < Record
-  def self.resource_name
-    'nodes'
-  end
-
-  belongs_to :group, class_name: 'GroupRecord', shallow_path: true
-
-  property :name, type: :string
-  property :params, type: :hash
-end
-
-class GroupRecord < Record
-  def self.resource_name
-    'groups'
+DEFAULT_LOGGER = Logger.new($stdout).tap do |logger|
+  case Sinatra::Application.environment
+  when :production
+    logger.level = Logger::INFO
+  when :test
+    logger.level = Logger::ERROR
+  else
+    logger.level = Logger::DEBUG
   end
 end
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Power Server.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Power Server is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Cloud. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Power Server, please visit:
+# https://github.com/openflighthpc/power-server
+#===============================================================================
+
+port 6302

--- a/config/topology.example.yaml
+++ b/config/topology.example.yaml
@@ -27,66 +27,62 @@
 # https://github.com/openflighthpc/power-server
 #===============================================================================
 
-# Define a static set of Nodes (Can not be used with remote key)
-static_nodes:
-  node01:
-    platform: aws
-    ec2_id: i-node01xxxxxxxxxxx
-    region: eu-west-1
-  node02:
-    platform: aws
-    ec2_id: i-node02xxxxxxxxxxx
-    region: eu-west-1
-  node03:
-    platform: aws
-    ec2_id: i-node03xxxxxxxxxxx
-    region: eu-west-1
-  node04:
-    platform: aws
-    ec2_id: i-node04xxxxxxxxxxx
-    region: eu-west-1
-  node05:
-    platform: aws
-    ec2_id: i-node05xxxxxxxxxxx
-    region: eu-west-1
-  gpu01:
-    platform: azure
-    resource_group: demo-power-group
-  gpu02:
-    platform: azure
-    resource_group: demo-power-group
-  gpu03:
-    platform: azure
-    resource_group: demo-power-group
-  gpu04:
-    platform: azure
-    resource_group: demo-power-group
-  gpu05:
-    platform: azure
-    resource_group: demo-power-group
-  metal01:
-    platform: ipmi
-    ipmi_username: admin
-  metal02:
-    platform: ipmi
-    ipmi_username: admin
-  metal03:
-    platform: ipmi
-    ipmi_username: admin
-  metal04:
-    platform: ipmi
-    ipmi_username: admin
-  metal05:
-    platform: ipmi
-    ipmi_username: admin
-  # This config does not check for missing platforms. Instead missing platforms
-  # will always run 'exit 1' as there commands
-  badnode:
-    platform: missing_platform
-
-# Integrate with OpenFlighHPC/NodeattrServer. This provides full groups support
-# and dynamic node parameters. Can not be used with the `static_nodes` key
-# remote: https://localhost:6301
+# Uncomment to define a static set of nodes (Can not be used in upstream mode)
+# static_nodes:
+#   node01:
+#     platform: aws
+#     ec2_id: i-node01xxxxxxxxxxx
+#     region: eu-west-1
+#   node02:
+#     platform: aws
+#     ec2_id: i-node02xxxxxxxxxxx
+#     region: eu-west-1
+#   node03:
+#     platform: aws
+#     ec2_id: i-node03xxxxxxxxxxx
+#     region: eu-west-1
+#   node04:
+#     platform: aws
+#     ec2_id: i-node04xxxxxxxxxxx
+#     region: eu-west-1
+#   node05:
+#     platform: aws
+#     ec2_id: i-node05xxxxxxxxxxx
+#     region: eu-west-1
+#   gpu01:
+#     platform: azure
+#     resource_group: demo-power-group
+#   gpu02:
+#     platform: azure
+#     resource_group: demo-power-group
+#   gpu03:
+#     platform: azure
+#     resource_group: demo-power-group
+#   gpu04:
+#     platform: azure
+#     resource_group: demo-power-group
+#   gpu05:
+#     platform: azure
+#     resource_group: demo-power-group
+#   metal01:
+#     platform: ipmi
+#     ipmi_username: admin
+#   metal02:
+#     platform: ipmi
+#     ipmi_username: admin
+#   metal03:
+#     platform: ipmi
+#     ipmi_username: admin
+#   metal04:
+#     platform: ipmi
+#     ipmi_username: admin
+#   metal05:
+#     platform: ipmi
+#     ipmi_username: admin
+#   # This config does not check for missing platforms. Instead missing platforms
+#   # will always run 'exit 1' as there commands
+#   badnode:
+#     platform: missing_platform
 
 # Define the platforms here
 platforms:

--- a/config/topology.example.yaml
+++ b/config/topology.example.yaml
@@ -27,8 +27,8 @@
 # https://github.com/openflighthpc/power-server
 #===============================================================================
 
-# Create a basic demo cluster
-nodes:
+# Define a static set of Nodes (Can not be used with remote key)
+static_nodes:
   node01:
     platform: aws
     ec2_id: i-node01xxxxxxxxxxx
@@ -83,6 +83,10 @@ nodes:
   # will always run 'exit 1' as there commands
   badnode:
     platform: missing_platform
+
+# Integrate with OpenFlighHPC/NodeattrServer. This provides full groups support
+# and dynamic node parameters. Can not be used with the `static_nodes` key
+# remote: https://localhost:6301
 
 # Define the platforms here
 platforms:


### PR DESCRIPTION
The `power-server` now has the ability to proxy request to a `nodeattr-server` for the `node` parameters. This allows the cluster to be dynamically defined in the background and manage the nodes.