### PR TITLE
Fix the logging within systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ The `puma` server daemon can be started manually with:
 
 ```
 bin/puma -p <port> -e production -d \
+         --redirect-append \
          --redirect-stdout <stdout-log-file-path> \
          --redirect-stderr <stderr-log-file-path>
 ```

--- a/README.md
+++ b/README.md
@@ -157,9 +157,18 @@ HTTP/1.1 200 OK
 
 The `platform` is extracted from the `params` hash and therefore may not be set. In this case a dummy "missing" platform is used which causes all the system commands to fail. All the other `params` are made available as replacements to the platform scripts.
 
-### Setting Up Systemd
+### Integrating with OpenFlightHPC/FlightRunway
 
-A basic `systemd` unit file can be found [here](support/power-server.service). The unit file will need to be tweaked according to where the application has been installed/configured. The unit needs to be stored within `/etc/systemd/system`.
+The [provided systemd unit file](support/power-server.service) has been designed to integrate with the `OpenFlightHPC` [flight-runway](https://github.com/openflighthpc/flight-runway) package. The following preconditions must be satisfied for the unit file to work:
+1. `OpenFlightHPC` `flight-runway` must be installed,
+2. The server must be installed as `/otp/flight/opt/power-server`,
+3. The log directory must exist: `/opt/flight/log`, and
+4. The configuration file must exist: `/opt/flight/etc/power-server.conf`.
+
+The configuration file will be loaded into the environment by `systemd` and can be used to override values within `config/application.yaml`. This is the recommended way to set the custom configuration values and provides the following benefits:
+1. The config will be preserved on update,
+2. It keeps the secret keys separate from the code base, and
+3. It eliminates the need to source a `bashrc` in order to setup the environment.
 
 ## Starting the Server
 

--- a/app/command.rb
+++ b/app/command.rb
@@ -83,7 +83,12 @@ Command = Struct.new(:action, :node) do
       #{args}
 
       # Run: #{node.platform}:#{action}
-      #{platform[action]}
+      #{
+        [
+          (action == :status ? "# Off Exit Code: #{platform.status_off_exit_code}" : nil),
+          platform[action]
+        ].reject(&:nil?).join("\n")
+      }
     CMD
   end
   memoize :cmd

--- a/app/records.rb
+++ b/app/records.rb
@@ -31,7 +31,7 @@ require 'json_api_client'
 
 class Record < JsonApiClient::Resource
   self.site = Figaro.env.remote_url
-  self.connection.faraday.authorization :Bearer, Figaro.env.remote_jwt
+  self.connection.faraday.authorization :Bearer, (Figaro.env.remote_jwt || '')
   connection.use Faraday::Response::Logger, DEFAULT_LOGGER, { bodies: true } do |logger|
     logger.filter(/(Authorization:)(.*)/, '\1 [REDACTED]')
   end

--- a/support/power-server.service
+++ b/support/power-server.service
@@ -11,9 +11,9 @@ WorkingDirectory=/opt/flight/opt/power-server
 
 # The application must be fully configured within the user's environment OR
 # within 'config/application.yaml'
-ExecStart=bin/puma -p 6302 -e production \
-                    --redirect-stdout /opt/flight/log/power-server.log \
-                    --redirect-stderr /opt/flight/log/power-server.log
+ExecStart=/opt/flight/opt/power-server/bin/puma -p 6302 -e production \
+            --redirect-stdout /opt/flight/log/power-server.log \
+            --redirect-stderr /opt/flight/log/power-server.log
 
 Restart=always
 

--- a/support/power-server.service
+++ b/support/power-server.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Flight Power Server
 Requires=network.target
+Wants=nodeattr-server.service
 
 [Service]
 Type=forking

--- a/support/power-server.service
+++ b/support/power-server.service
@@ -3,18 +3,19 @@ Description=Flight Power Server
 Requires=network.target
 
 [Service]
-Type=simple
+Type=forking
 User=root
-
-# The working directory needs to be where the application has been installed
+PIDFile=/opt/flight/opt/power-server/var/puma.pid
+Environment=PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/flight/bin
+EnvironmentFile=/opt/flight/etc/power-server.conf
 WorkingDirectory=/opt/flight/opt/power-server
-
-# The application must be fully configured within the user's environment OR
-# within 'config/application.yaml'
-ExecStart=/opt/flight/opt/power-server/bin/puma -p 6302 -e production \
-            --redirect-stdout /opt/flight/log/power-server.log \
-            --redirect-stderr /opt/flight/log/power-server.log
-
+ExecStart=/bin/sh -c ' \
+  bin/puma -d -e production \
+    --redirect-append \
+    --redirect-stdout /opt/flight/log/power-server.log \
+    --redirect-stderr /opt/flight/log/power-server.log \
+'
+ExecStop=/opt/flight/opt/power-server/bin/pumactl stop
 Restart=always
 
 [Install]


### PR DESCRIPTION
Fix small issues on how the server logs when started with `systemd`. It also loads a config file so the configuration does not need to be loaded using a `bashrc`