### PR TITLE
Shell escape the arguments to close security loophole

### DIFF
--- a/app/command.rb
+++ b/app/command.rb
@@ -30,6 +30,7 @@
 require 'open3'
 require 'memoist'
 require 'parallel'
+require 'shellwords'
 
 Commands = Struct.new(:action, :nodes) do
   extend Memoist
@@ -73,8 +74,9 @@ Command = Struct.new(:action, :node) do
 
   def cmd
     args = platform.variables
-                   .map { |v| "#{v}=\"#{node.attributes[v]}\"" }
-                   .join("\n")
+                   .map do |v|
+                     "#{v}=\"#{Shellwords.escape(node.attributes[v])}\""
+                   end.join("\n")
     <<~CMD
       # Working Directory:
       cd #{self.class.working_dir}


### PR DESCRIPTION
Now that the arguments come from an external source, the possibility of an injection attack must be considered. As such, all arguments are now shell escaped to prevent them from running malicious commands