### PR TITLE
Remove OpenFlight Tools Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Power Server
 
-Platform agnostic utility for preforming power commands across a HPC cluster
+Platform agnostic utility for performing power commands across a HPC cluster
 
 ## Overview
 
@@ -161,7 +161,7 @@ The `platform` is extracted from the `params` hash and therefore may not be set.
 
 The [provided systemd unit file](support/power-server.service) has been designed to integrate with the `OpenFlightHPC` [flight-runway](https://github.com/openflighthpc/flight-runway) package. The following preconditions must be satisfied for the unit file to work:
 1. `OpenFlightHPC` `flight-runway` must be installed,
-2. The server must be installed as `/otp/flight/opt/power-server`,
+2. The server must be installed as `/opt/flight/opt/power-server`,
 3. The log directory must exist: `/opt/flight/log`, and
 4. The configuration file must exist: `/opt/flight/etc/power-server.conf`.
 
@@ -231,8 +231,6 @@ If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ![Creative Commons License](https://i.creativecommons.org/l/by-sa/4.0/88x31.png)
 
 Power Server is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
-
-Based on a work at [https://github.com/openflighthpc/openflight-tools](https://github.com/openflighthpc/openflight-tools).
 
 This content and the accompanying materials are made available available
 under the terms of the Creative Commons Attribution-ShareAlike 4.0

--- a/README.md
+++ b/README.md
@@ -221,28 +221,10 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
 # Copyright and License
 
-Creative Commons Attribution-ShareAlike 4.0 License, see [LICENSE.txt](LICENSE.txt) for details.
+Eclipse Public License 2.0, see LICENSE.txt for details.
 
 Copyright (C) 2019-present Alces Flight Ltd.
 
-You should have received a copy of the license along with this work.
-If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
+This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0, or alternative license terms made available by Alces Flight Ltd - please direct inquiries about licensing to licensing@alces-flight.com.
 
-![Creative Commons License](https://i.creativecommons.org/l/by-sa/4.0/88x31.png)
-
-Power Server is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
-
-This content and the accompanying materials are made available available
-under the terms of the Creative Commons Attribution-ShareAlike 4.0
-International License which is available at [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/),
-or alternative license terms made available by Alces Flight Ltd -
-please direct inquiries about licensing to
-[licensing@alces-flight.com](mailto:licensing@alces-flight.com).
-
-Power Server is distributed in the hope that it will be useful, but
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
-IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
-TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
-PURPOSE. See the [Creative Commons Attribution-ShareAlike 4.0
-International License](https://creativecommons.org/licenses/by-sa/4.0/) for more
-details.
+PowerServer is distributed in the hope that it will be useful, but WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more details.


### PR DESCRIPTION
As part of the tidy up of OpenFlight documentation, references to openflight-tools should be removed. It looks like there is a ref in the licensing that mentions the work being based off of openflight tools. Is this correct?

Additionally tidied a couple of typos.